### PR TITLE
rm global wat2wasm dependency by using emilbayes/wat2wasm

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ npm install -g wat2js
 
 See https://github.com/WebAssembly/wabt for more WebAssembly goodies.
 
-Currently requires the `wat2wasm` program to be installed globally. If you don't have that already you can get that by installing the webassembly binary toolkit by using this little [helper](https://github.com/mafintosh/webassembly-binary-toolkit)
-
 ## Usage
 
 First make a basic WebAssembly .wat file

--- a/index.js
+++ b/index.js
@@ -38,7 +38,9 @@ function compile () {
   var tmp = path.join(os.tmpdir(), 'out.wasm.' + Date.now())
 
   var wat2wasmArgv = [inp, '-o', tmp].concat(argv['--'])
-  proc.spawn(os.platform() === 'win32' ? 'wat2wasm.cmd' : 'wat2wasm', wat2wasmArgv, {stdio: 'inherit'}).on('exit', function (code) {
+  var wat2wasm = path.join(__dirname, 'node_modules', '.bin', os.platform() === 'win32' ? 'wat2wasm.cmd' : 'wat2wasm')
+
+  proc.spawn(wat2wasm, wat2wasmArgv, {stdio: 'inherit'}).on('exit', function (code) {
     if (code) {
       if (argv.watch) return
       process.exit(1)

--- a/package.json
+++ b/package.json
@@ -8,7 +8,12 @@
     "wasm2js": "~0.2.0",
     "wat2wasm": "~1.0.2"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "tape": "^4.9.1"
+  },
+  "scripts": {
+    "test": "tape ./test.js"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/mafintosh/wat2js.git"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "dependencies": {
     "minimist": "^1.2.0",
-    "wasm2js": "~0.2.0"
+    "wasm2js": "~0.2.0",
+    "wat2wasm": "~1.0.2"
   },
   "devDependencies": {},
   "repository": {

--- a/test.js
+++ b/test.js
@@ -1,0 +1,17 @@
+var tape = require('tape')
+var execSync = require('child_process').execSync
+var unlinkSync = require('fs').unlinkSync
+
+tape('test example', function (t) {
+  var tst = './.test.example.' + Date.now() + '.js'
+  var cmd = 'node ./index.js ./example.wat -o ' + tst
+
+  execSync(cmd)
+
+  var mod = require(tst)()
+
+  t.equal(mod.exports.add(417, 2), 419, 'wasm add')
+
+  unlinkSync(tst)
+  t.end()
+})


### PR DESCRIPTION
would allow using sth like `npx wat2js ./index.wat > ./index.wasm.js` as an npm script