### PR TITLE
Note the WASM version of wat2wasm

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ npm install -g wat2js
 
 See https://github.com/WebAssembly/wabt for more WebAssembly goodies.
 
-Currently requires the `wat2wasm` program to be installed globally. If you don't have that already you can get that by installing the webassembly binary toolkit by using this little [helper](https://github.com/mafintosh/webassembly-binary-toolkit)
+Currently requires the `wat2wasm` program to be installed globally. If you don't have that already you can get that by installing the whole webassembly binary toolkit by using this little [helper](https://github.com/mafintosh/webassembly-binary-toolkit), or by installing [wat2wasm](https://github.com/emilbayes/wat2wasm) (the WASM compiled version of `wabt`'s `wat2wasm`) from npm.
 
 ## Usage
 


### PR DESCRIPTION
Add some additional context around the WASM version of wat2wasm.  A bit easier to use than the `wabt` helper.  